### PR TITLE
Fix deprecation warnings for elixir 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule Ngram.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
In order to silence deprecation warnings in elixir 1.4+, call methods using params in the mix file.