### PR TITLE
Convert chunk to chunk_every for Elixir >1.4

### DIFF
--- a/lib/ngram.ex
+++ b/lib/ngram.ex
@@ -5,7 +5,7 @@ defmodule Ngram do
   """
 
   @ngram_size 2
-  @token_type :letter 
+  @token_type :letter
   @doc """
   tokenize a string into n-grams
 
@@ -28,12 +28,12 @@ defmodule Ngram do
   def tokenize(str, n, token_type) when is_binary(str) do
     case token_type do
       :letter -> tokenize(String.codepoints(str), n)
-      :word   -> Enum.map(Enum.chunk( String.split(str, " ") ,n,1), fn(token) -> Enum.join(token, " ")  end)
+      :word   -> Enum.map(Enum.chunk_every( String.split(str, " ") ,n,1, :discard), fn(token) -> Enum.join(token, " ")  end)
     end
   end
   def tokenize(chars, n, _) when n <= 0 or length(chars) <0, do: :nil
   def tokenize(chars, n, _) do
-      Enum.chunk(chars, n, 1) |> Enum.map(&(to_string(&1)))
+      Enum.chunk_every(chars, n, 1, :discard) |> Enum.map(&(to_string(&1)))
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ngram.Mixfile do
   def project do
     [app: :ngram,
      version: "0.0.1",
-     elixir: "~> 1.1",
+     elixir: "~> 1.5",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: description(),

--- a/test/ngram_test.exs
+++ b/test/ngram_test.exs
@@ -2,4 +2,31 @@ defmodule NgramTest do
   use ExUnit.Case, async: true
   doctest Ngram
 
+  describe "tokenize/3" do
+    test "tokenize/1 with module defaults" do
+      assert ["ab", "bc", "cd", "de", "ef"] == Ngram.tokenize("abcdef")
+    end
+
+    test "tokenize/3 ngram 2, token = word" do
+      assert ["free world"] == Ngram.tokenize("free world", 2, :word)
+    end
+
+    test "tokenize with 2-gram letter tokens" do
+      assert ["fr", "re", "ee", "e ", " w", "wo", "or", "rl", "ld"] == Ngram.tokenize("free world", 2)
+    end
+  end
+
+  describe "calculate/3" do
+    test "integer lists" do
+      assert 0.5 == Ngram.calculate([1,2,3], [2,3])
+    end
+
+    test "character with module defaults" do
+      assert 0.0 == Ngram.calculate("lorem", "ipsum")
+    end
+
+    test "character with 2-char strings" do
+      assert 0.0 == Ngram.calculate("li", "il")
+    end
+  end
 end


### PR DESCRIPTION
Elixir 1.5 introduces [chunk_every/2](https://hexdocs.pm/elixir/Enum.html#chunk_every/2) and removes support for Enum.chunk. 

This bumps the mix Elixir dep to 1.5 and migrates the calls to chunk to chunk_every. 

It also adds some basic regression tests, pulled almost exactly from the nice docs. 